### PR TITLE
Add NoGraphics field to tart get command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist/
 
 # mkdocs-material
 site
+
+# Python cache files
+*.pyc

--- a/Sources/tart/Commands/Get.swift
+++ b/Sources/tart/Commands/Get.swift
@@ -1,5 +1,6 @@
 import ArgumentParser
 import Foundation
+import Darwin
 
 fileprivate struct VMInfo: Encodable {
   let OS: OS
@@ -11,6 +12,29 @@ fileprivate struct VMInfo: Encodable {
   let Display: String
   let Running: Bool
   let State: String
+  let NoGraphics: Bool?
+
+  enum CodingKeys: String, CodingKey {
+    case OS, CPU, Memory, Disk, DiskFormat, Size, Display, Running, State, NoGraphics
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(OS, forKey: .OS)
+    try container.encode(CPU, forKey: .CPU)
+    try container.encode(Memory, forKey: .Memory)
+    try container.encode(Disk, forKey: .Disk)
+    try container.encode(DiskFormat, forKey: .DiskFormat)
+    try container.encode(Size, forKey: .Size)
+    try container.encode(Display, forKey: .Display)
+    try container.encode(Running, forKey: .Running)
+    try container.encode(State, forKey: .State)
+    if let noGraphics = NoGraphics {
+      try container.encode(noGraphics, forKey: .NoGraphics)
+    } else {
+      try container.encodeNil(forKey: .NoGraphics)
+    }
+  }
 }
 
 struct Get: AsyncParsableCommand {
@@ -27,7 +51,47 @@ struct Get: AsyncParsableCommand {
     let vmConfig = try VMConfig(fromURL: vmDir.configURL)
     let memorySizeInMb = vmConfig.memorySize / 1024 / 1024
 
-    let info = VMInfo(OS: vmConfig.os, CPU: vmConfig.cpuCount, Memory: memorySizeInMb, Disk: try vmDir.sizeGB(), DiskFormat: vmConfig.diskFormat.rawValue, Size: String(format: "%.3f", Float(try vmDir.allocatedSizeBytes()) / 1000 / 1000 / 1000), Display: vmConfig.display.description, Running: try vmDir.running(), State: try vmDir.state().rawValue)
+    // Check if VM is running with --no-graphics
+    var noGraphics: Bool? = nil
+    if try vmDir.running() {
+      let lock = try vmDir.lock()
+      let pid = try lock.pid()
+      if pid > 0 {
+        noGraphics = try checkNoGraphicsFlag(pid: pid)
+      }
+    }
+
+    let info = VMInfo(OS: vmConfig.os, CPU: vmConfig.cpuCount, Memory: memorySizeInMb, Disk: try vmDir.sizeGB(), DiskFormat: vmConfig.diskFormat.rawValue, Size: String(format: "%.3f", Float(try vmDir.allocatedSizeBytes()) / 1000 / 1000 / 1000), Display: vmConfig.display.description, Running: try vmDir.running(), State: try vmDir.state().rawValue, NoGraphics: noGraphics)
     print(format.renderSingle(info))
+  }
+
+  private func checkNoGraphicsFlag(pid: pid_t) throws -> Bool {
+    // Get process arguments using sysctl
+    var mib = [CTL_KERN, KERN_PROCARGS2, pid]
+    var size: size_t = 0
+
+    // Get the size of the buffer needed
+    if sysctl(&mib, 3, nil, &size, nil, 0) != 0 {
+      // Process might have exited or we don't have permission
+      return false
+    }
+
+    // Allocate buffer and get the data
+    var buffer = [UInt8](repeating: 0, count: size)
+    if sysctl(&mib, 3, &buffer, &size, nil, 0) != 0 {
+      return false
+    }
+
+    // Parse the buffer to extract command line arguments
+    // The format is: argc (4 bytes) + executable path + \0 + args...
+    if size < 4 {
+      return false
+    }
+
+    // Convert buffer to string and look for --no-graphics
+    let data = Data(bytes: buffer, count: size)
+    let str = String(data: data, encoding: .utf8) ?? ""
+
+    return str.contains("--no-graphics")
   }
 }

--- a/integration-tests/test_no_graphics.py
+++ b/integration-tests/test_no_graphics.py
@@ -1,0 +1,59 @@
+import json
+import os
+import subprocess
+import time
+import uuid
+
+import pytest
+
+
+def check_json_format(tart, vm_name, running, noGraphics, expected):
+    stdout, _ = tart.run(["get", vm_name, "--format", "json"])
+    vm_info = json.loads(stdout)
+    actual_running = vm_info["Running"]
+    assert actual_running is running, f"Running is {actual_running}, expected {running}"
+    assert vm_info.get("NoGraphics") is noGraphics, expected
+
+def check_text_format(tart, vm_name, running, noGraphics, expected):
+    stdout, _ = tart.run(["get", vm_name, "--format", "text"])
+    assert "NoGraphics" in stdout, "NoGraphics field should be present in text output"
+
+    # Text format is tab-separated with headers in first line
+    lines = stdout.strip().split('\n')
+    if len(lines) >= 2:
+        headers = lines[0].split()
+        values = lines[1].split()
+        info_dict = dict(zip(headers, values))
+    else:
+        info_dict = {}
+
+    # Convert "stopped" to false for Running field
+    actual_running = info_dict.get("State") != "stopped"
+    assert actual_running == running, f"Expected Running={running}, got State={actual_running}"
+    assert info_dict.get("NoGraphics") == noGraphics, expected
+
+@pytest.mark.parametrize("graphics_mode,expected_no_graphics", [
+    ([], False),                # Normal run (with graphics)
+    (["--no-graphics"], True),  # Run with --no-graphics
+])
+def test_no_graphics(tart, graphics_mode, expected_no_graphics):
+    # Create a test VM (use Linux VM for faster tests)
+    vm_name = f"integration-test-no-graphics-{uuid.uuid4()}"
+    tart.run(["pull", "ghcr.io/cirruslabs/debian:latest"])
+    tart.run(["clone", "ghcr.io/cirruslabs/debian:latest", vm_name])
+
+    # Test 1: VM not running - NoGraphics should be None in json format
+    check_json_format(tart, vm_name, False, None, "NoGraphics should be None when VM is not running")
+
+    # Test 2: VM not running - NoGraphics should be NULL in text format
+    check_text_format(tart, vm_name, False, "NULL", "NoGraphics should be NULL when VM is not running")
+
+    # Run VM with specified graphics mode
+    tart_run_process = tart.run_async(["run"] + graphics_mode + [vm_name])
+    time.sleep(3)  # Give VM time to start
+
+    # Test 3: VM running - NoGraphics should be XX in json format
+    check_json_format(tart, vm_name, True, expected_no_graphics, f"NoGraphics should be {expected_no_graphics} (JSON) when VM is running")
+
+    # Test 4: VM running - NoGraphics should be XX in text format
+    check_text_format(tart, vm_name, True, str(expected_no_graphics).lower(), f"NoGraphics should be {expected_no_graphics} (TEXT) when VM is running")


### PR DESCRIPTION
I need to be able to detect whether a VM is running with `--no-graphics` for [ClodPod](https://github.com/webcoyote/clodpod) (VM sandbox for AI agents), so I added a feature to `tart`:

- Added `NoGraphics` field to the `tart get` command output that indicates whether a VM is running with the `--no-graphics` flag
- Returns `true` when `--no-graphics` is present, `false` when graphics are enabled, and `null` when VM is not running
- Includes integration tests to verify the functionality

Glad to make changes; I agonized over whether the field should be `NoGraphics: true/false` or `Graphics: false/true`.